### PR TITLE
Fix events text overflow

### DIFF
--- a/blocks/events/__card-detail/events__card-detail.css
+++ b/blocks/events/__card-detail/events__card-detail.css
@@ -1,5 +1,6 @@
 .events__card-detail {
     margin: 0;
+    max-width: 200px;
     line-height: 20px;
     font-size: 16px;
     font-weight: 400;
@@ -7,6 +8,6 @@
     color: #96949E;
 
     text-overflow: ellipsis;
-    white-space: wrap;
+    white-space: nowrap;
     overflow: hidden;
 }

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                 <p class="events__card-description">капучино, эспрессо и американо в пользу Ночлежки</p>
               </div>
               <div class="events__card-details-container events__card-details-container_position_bottom">
-                <p class="events__card-detail events__card-detail_type_place">Малая Конюшенная улиц...</p>
+                <p class="events__card-detail events__card-detail_type_place">Малая Конюшенная улица, </p>
                 <a href="#" class="events__card-detail events__card-detail_type_extra-options">+ ещё <span
                     class="events__counter">4</span></a>
               </div>

--- a/pages/index.css
+++ b/pages/index.css
@@ -101,6 +101,7 @@
 @import url(../blocks/events/__card-title/events__card-title.css);
 @import url(../blocks/events/__card-description/events__card-description.css);
 @import url(../blocks/events/__card-detail/events__card-detail.css);
+@import url(../blocks/events/__card-detail/_type/events__card-detail_type_extra-options.css);
 
 @import url(../blocks/numbers/numbers.css);
 @import url(../blocks/numbers/__wrapper/numbers__wrapper.css);

--- a/pages/index.css
+++ b/pages/index.css
@@ -101,7 +101,6 @@
 @import url(../blocks/events/__card-title/events__card-title.css);
 @import url(../blocks/events/__card-description/events__card-description.css);
 @import url(../blocks/events/__card-detail/events__card-detail.css);
-@import url(../blocks/events/__card-detail/_type/events__card-detail_type_extra-options.css);
 
 @import url(../blocks/numbers/numbers.css);
 @import url(../blocks/numbers/__wrapper/numbers__wrapper.css);


### PR DESCRIPTION
Добавил корректное переполнение теста для данных элементов карточки, чтобы они не "выталкивали" остальные элементы карточки при переполнение и оставались в размерах одной строки.
![Снимок](https://user-images.githubusercontent.com/27924581/143574821-020a0425-6317-4937-8463-a409e31c3331.PNG)

